### PR TITLE
Feat: 인증 좋아요 기능 구현

### DIFF
--- a/src/main/java/com/senity/waved/base/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/senity/waved/base/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.senity.waved.base.exception;
 import com.senity.waved.domain.challengeGroup.exception.ChallengeGroupNotCompletedException;
 import com.senity.waved.domain.challengeGroup.exception.ChallengeGroupNotFoundException;
 import com.senity.waved.domain.liked.exception.DuplicationLikeException;
+import com.senity.waved.domain.liked.exception.LikeNotAuthorizedException;
 import com.senity.waved.domain.member.exception.InvalidRefreshTokenException;
 import com.senity.waved.domain.member.exception.MemberNotFoundException;
 import com.senity.waved.domain.member.exception.WrongGithubInfoException;
@@ -109,6 +110,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(DuplicationLikeException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public String handleDuplicationLikeException(DuplicationLikeException e) {
+        return e.getMessage();
+    }
+
+    @ExceptionHandler(LikeNotAuthorizedException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String handleLikeNotAuthorizedException(LikeNotAuthorizedException e) {
         return e.getMessage();
     }
 

--- a/src/main/java/com/senity/waved/base/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/senity/waved/base/exception/GlobalExceptionHandler.java
@@ -15,6 +15,7 @@ import com.senity.waved.domain.review.exception.ReviewNotFoundException;
 import com.senity.waved.domain.verification.exception.AlreadyVerifiedException;
 import com.senity.waved.domain.verification.exception.ChallengeGroupVerificationException;
 import com.senity.waved.domain.verification.exception.VerificationNotFoundException;
+import com.senity.waved.domain.verification.exception.VerifyExistenceOnDate;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -116,6 +117,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(LikeNotAuthorizedException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public String handleLikeNotAuthorizedException(LikeNotAuthorizedException e) {
+        return e.getMessage();
+    }
+
+    @ExceptionHandler(VerifyExistenceOnDate.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String handleVerifyExistenceOnDate(VerifyExistenceOnDate e) {
         return e.getMessage();
     }
 

--- a/src/main/java/com/senity/waved/base/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/senity/waved/base/exception/GlobalExceptionHandler.java
@@ -2,16 +2,18 @@ package com.senity.waved.base.exception;
 
 import com.senity.waved.domain.challengeGroup.exception.ChallengeGroupNotCompletedException;
 import com.senity.waved.domain.challengeGroup.exception.ChallengeGroupNotFoundException;
+import com.senity.waved.domain.liked.exception.DuplicationLikeException;
 import com.senity.waved.domain.member.exception.InvalidRefreshTokenException;
+import com.senity.waved.domain.member.exception.MemberNotFoundException;
 import com.senity.waved.domain.member.exception.WrongGithubInfoException;
 import com.senity.waved.domain.myChallenge.exception.AlreadyMyChallengeExistsException;
-import com.senity.waved.domain.member.exception.MemberNotFoundException;
 import com.senity.waved.domain.myChallenge.exception.MyChallengeNotFoundException;
 import com.senity.waved.domain.quiz.exception.QuizNotFoundException;
 import com.senity.waved.domain.review.exception.AlreadyReviewedException;
 import com.senity.waved.domain.review.exception.ReviewNotFoundException;
 import com.senity.waved.domain.verification.exception.AlreadyVerifiedException;
 import com.senity.waved.domain.verification.exception.ChallengeGroupVerificationException;
+import com.senity.waved.domain.verification.exception.VerificationNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -97,4 +99,17 @@ public class GlobalExceptionHandler {
     public String handleAlreadyVerifiedException(AlreadyVerifiedException e) {
         return e.getMessage();
     }
+
+    @ExceptionHandler(VerificationNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String handleVerificationNotFoundException(VerificationNotFoundException e) {
+        return e.getMessage();
+    }
+
+    @ExceptionHandler(DuplicationLikeException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String handleDuplicationLikeException(DuplicationLikeException e) {
+        return e.getMessage();
+    }
+
 }

--- a/src/main/java/com/senity/waved/domain/challengeGroup/controller/ChallengeGroupController.java
+++ b/src/main/java/com/senity/waved/domain/challengeGroup/controller/ChallengeGroupController.java
@@ -42,9 +42,10 @@ public class ChallengeGroupController {
     @GetMapping("/dates")
     public ResponseEntity<List<VerificationListResponseDto>> getVerificationsByDate(
             @PathVariable("challengeGroupId") Long challengeGroupId,
-            @RequestParam("verificationDate") Timestamp verificationDate) {
-        List<VerificationListResponseDto> verifications = challengeGroupService.getVerifications(challengeGroupId, verificationDate);
+            @RequestParam("verificationDate") Timestamp verificationDate,
+            @AuthenticationPrincipal User user) {
+        List<VerificationListResponseDto> verifications =
+                challengeGroupService.getVerifications(user.getUsername(), challengeGroupId, verificationDate);
         return ResponseEntity.ok(verifications);
     }
 }
-

--- a/src/main/java/com/senity/waved/domain/challengeGroup/dto/response/VerificationListResponseDto.java
+++ b/src/main/java/com/senity/waved/domain/challengeGroup/dto/response/VerificationListResponseDto.java
@@ -1,5 +1,6 @@
 package com.senity.waved.domain.challengeGroup.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.senity.waved.domain.verification.entity.Verification;
 import lombok.Getter;
 import lombok.Setter;
@@ -15,9 +16,13 @@ public class VerificationListResponseDto {
     private String content;
     private ZonedDateTime verificationDate;
 
-    public VerificationListResponseDto(Verification verification) {
+    @JsonProperty("isLiked")
+    private boolean isLiked;
+
+    public VerificationListResponseDto(Verification verification, boolean isLiked) {
         this.verificationId = verification.getId();
         this.content = verification.getContent();
+        this.isLiked = isLiked;
 
         if (verification.getCreateDate() != null) {
             LocalDateTime localDateTime = verification.getCreateDate().toLocalDateTime();
@@ -25,4 +30,3 @@ public class VerificationListResponseDto {
         }
     }
 }
-

--- a/src/main/java/com/senity/waved/domain/challengeGroup/dto/response/VerificationListResponseDto.java
+++ b/src/main/java/com/senity/waved/domain/challengeGroup/dto/response/VerificationListResponseDto.java
@@ -15,6 +15,7 @@ public class VerificationListResponseDto {
     private Long verificationId;
     private String content;
     private ZonedDateTime verificationDate;
+    private Long likesCount;
 
     @JsonProperty("isLiked")
     private boolean isLiked;
@@ -23,6 +24,7 @@ public class VerificationListResponseDto {
         this.verificationId = verification.getId();
         this.content = verification.getContent();
         this.isLiked = isLiked;
+        this.likesCount = verification.getLikesCount();
 
         if (verification.getCreateDate() != null) {
             LocalDateTime localDateTime = verification.getCreateDate().toLocalDateTime();

--- a/src/main/java/com/senity/waved/domain/challengeGroup/service/ChallengeGroupService.java
+++ b/src/main/java/com/senity/waved/domain/challengeGroup/service/ChallengeGroupService.java
@@ -10,5 +10,5 @@ public interface ChallengeGroupService {
 
     void applyForChallengeGroup(String email, Long groupId);
     ChallengeGroupResponseDto getGroupDetail(String email, Long groupId);
-    List<VerificationListResponseDto> getVerifications(Long challengeGroupId, Timestamp verificationDate);
+    List<VerificationListResponseDto> getVerifications(String email, Long challengeGroupId, Timestamp verificationDate);
 }

--- a/src/main/java/com/senity/waved/domain/liked/controller/LikedController.java
+++ b/src/main/java/com/senity/waved/domain/liked/controller/LikedController.java
@@ -1,0 +1,4 @@
+package com.senity.waved.domain.liked.controller;
+
+public class LikedController {
+}

--- a/src/main/java/com/senity/waved/domain/liked/controller/LikedController.java
+++ b/src/main/java/com/senity/waved/domain/liked/controller/LikedController.java
@@ -34,4 +34,13 @@ public class LikedController {
         return ResponseEntity.ok(new LikedResponseDto(verificationId, likedCount));
     }
 
+    @DeleteMapping
+    public ResponseEntity<String> removeLikeFromVerification(
+            @PathVariable("verificationId") Long verificationId,
+            @AuthenticationPrincipal User user) {
+        likedService.removeLikeFromVerification(user.getUsername(), verificationId);
+
+        return new ResponseEntity<>("좋아요를 취소했습니다.", HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/com/senity/waved/domain/liked/controller/LikedController.java
+++ b/src/main/java/com/senity/waved/domain/liked/controller/LikedController.java
@@ -1,4 +1,31 @@
 package com.senity.waved.domain.liked.controller;
 
+import com.senity.waved.domain.liked.service.LikedService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/likes/{verificationId}")
 public class LikedController {
+
+    private final LikedService likedService;
+
+    @PostMapping
+    public ResponseEntity<String> addLikedToVerification(
+            @PathVariable("verificationId") Long verificationId,
+            @AuthenticationPrincipal User user) {
+        likedService.addLikedToVerification(user.getUsername(), verificationId);
+        return new ResponseEntity<>("좋아요를 추가했습니다.", HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/com/senity/waved/domain/liked/controller/LikedController.java
+++ b/src/main/java/com/senity/waved/domain/liked/controller/LikedController.java
@@ -1,5 +1,6 @@
 package com.senity.waved.domain.liked.controller;
 
+import com.senity.waved.domain.liked.dto.response.LikedResponseDto;
 import com.senity.waved.domain.liked.service.LikedService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -7,10 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -26,6 +24,14 @@ public class LikedController {
             @AuthenticationPrincipal User user) {
         likedService.addLikedToVerification(user.getUsername(), verificationId);
         return new ResponseEntity<>("좋아요를 추가했습니다.", HttpStatus.OK);
+    }
+
+    @GetMapping
+    public ResponseEntity<LikedResponseDto> getCountLikesByVerification(
+            @PathVariable("verificationId") Long verificationId) {
+        Long likedCount = likedService.countLikesToVerification(verificationId);
+
+        return ResponseEntity.ok(new LikedResponseDto(verificationId, likedCount));
     }
 
 }

--- a/src/main/java/com/senity/waved/domain/liked/dto/request/LikedRequestDto.java
+++ b/src/main/java/com/senity/waved/domain/liked/dto/request/LikedRequestDto.java
@@ -1,0 +1,4 @@
+package com.senity.waved.domain.liked.dto.request;
+
+public class LikedRequestDto {
+}

--- a/src/main/java/com/senity/waved/domain/liked/dto/request/LikedRequestDto.java
+++ b/src/main/java/com/senity/waved/domain/liked/dto/request/LikedRequestDto.java
@@ -1,4 +1,0 @@
-package com.senity.waved.domain.liked.dto.request;
-
-public class LikedRequestDto {
-}

--- a/src/main/java/com/senity/waved/domain/liked/dto/response/LikedResponseDto.java
+++ b/src/main/java/com/senity/waved/domain/liked/dto/response/LikedResponseDto.java
@@ -1,0 +1,4 @@
+package com.senity.waved.domain.liked.dto.response;
+
+public class LikedResponseDto {
+}

--- a/src/main/java/com/senity/waved/domain/liked/dto/response/LikedResponseDto.java
+++ b/src/main/java/com/senity/waved/domain/liked/dto/response/LikedResponseDto.java
@@ -1,10 +1,14 @@
 package com.senity.waved.domain.liked.dto.response;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class LikedResponseDto {
     private Long verificationId;
     private Long likedCount;

--- a/src/main/java/com/senity/waved/domain/liked/dto/response/LikedResponseDto.java
+++ b/src/main/java/com/senity/waved/domain/liked/dto/response/LikedResponseDto.java
@@ -1,4 +1,11 @@
 package com.senity.waved.domain.liked.dto.response;
 
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class LikedResponseDto {
+    private Long verificationId;
+    private Long likedCount;
 }

--- a/src/main/java/com/senity/waved/domain/liked/entity/Liked.java
+++ b/src/main/java/com/senity/waved/domain/liked/entity/Liked.java
@@ -1,0 +1,26 @@
+package com.senity.waved.domain.liked.entity;
+
+
+import com.senity.waved.common.BaseEntity;
+import com.senity.waved.domain.member.entity.Member;
+import com.senity.waved.domain.verification.entity.Verification;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder(toBuilder = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Liked extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "verification_id")
+    private Verification verification;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/com/senity/waved/domain/liked/entity/Liked.java
+++ b/src/main/java/com/senity/waved/domain/liked/entity/Liked.java
@@ -23,4 +23,12 @@ public class Liked extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    public void setVerification(Verification verification) {
+        this.verification = verification;
+    }
+
+    public void setMember(Member member) {
+        this.verification = verification;
+    }
 }

--- a/src/main/java/com/senity/waved/domain/liked/exception/DuplicationLikeException.java
+++ b/src/main/java/com/senity/waved/domain/liked/exception/DuplicationLikeException.java
@@ -1,0 +1,7 @@
+package com.senity.waved.domain.liked.exception;
+
+public class DuplicationLikeException extends RuntimeException {
+    public DuplicationLikeException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/senity/waved/domain/liked/exception/LikeNotAuthorizedException.java
+++ b/src/main/java/com/senity/waved/domain/liked/exception/LikeNotAuthorizedException.java
@@ -1,0 +1,7 @@
+package com.senity.waved.domain.liked.exception;
+
+public class LikeNotAuthorizedException extends RuntimeException {
+    public LikeNotAuthorizedException (String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/senity/waved/domain/liked/repository/LikedRepository.java
+++ b/src/main/java/com/senity/waved/domain/liked/repository/LikedRepository.java
@@ -1,0 +1,4 @@
+package com.senity.waved.domain.liked.repository;
+
+public interface LikedRepository {
+}

--- a/src/main/java/com/senity/waved/domain/liked/repository/LikedRepository.java
+++ b/src/main/java/com/senity/waved/domain/liked/repository/LikedRepository.java
@@ -1,4 +1,10 @@
 package com.senity.waved.domain.liked.repository;
 
-public interface LikedRepository {
+import com.senity.waved.domain.liked.entity.Liked;
+import com.senity.waved.domain.member.entity.Member;
+import com.senity.waved.domain.verification.entity.Verification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikedRepository extends JpaRepository<Liked, Long> {
+    boolean existsByMemberAndVerification(Member member, Verification verification);
 }

--- a/src/main/java/com/senity/waved/domain/liked/repository/LikedRepository.java
+++ b/src/main/java/com/senity/waved/domain/liked/repository/LikedRepository.java
@@ -5,8 +5,12 @@ import com.senity.waved.domain.member.entity.Member;
 import com.senity.waved.domain.verification.entity.Verification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface LikedRepository extends JpaRepository<Liked, Long> {
     boolean existsByMemberAndVerification(Member member, Verification verification);
 
     Long countLikesByVerification(Verification verification);
+
+    Optional<Liked> findByMemberAndVerification(Member member, Verification verification);
 }

--- a/src/main/java/com/senity/waved/domain/liked/repository/LikedRepository.java
+++ b/src/main/java/com/senity/waved/domain/liked/repository/LikedRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LikedRepository extends JpaRepository<Liked, Long> {
     boolean existsByMemberAndVerification(Member member, Verification verification);
+
+    Long countLikesByVerification(Verification verification);
 }

--- a/src/main/java/com/senity/waved/domain/liked/service/LikedService.java
+++ b/src/main/java/com/senity/waved/domain/liked/service/LikedService.java
@@ -3,4 +3,5 @@ package com.senity.waved.domain.liked.service;
 public interface LikedService {
     void addLikedToVerification(String email, Long verificationId);
     Long countLikesToVerification(Long verificationId);
+    void removeLikeFromVerification(String email, Long verificationId);
 }

--- a/src/main/java/com/senity/waved/domain/liked/service/LikedService.java
+++ b/src/main/java/com/senity/waved/domain/liked/service/LikedService.java
@@ -2,4 +2,5 @@ package com.senity.waved.domain.liked.service;
 
 public interface LikedService {
     void addLikedToVerification(String email, Long verificationId);
+    Long countLikesToVerification(Long verificationId);
 }

--- a/src/main/java/com/senity/waved/domain/liked/service/LikedService.java
+++ b/src/main/java/com/senity/waved/domain/liked/service/LikedService.java
@@ -1,4 +1,5 @@
 package com.senity.waved.domain.liked.service;
 
 public interface LikedService {
+    void addLikedToVerification(String email, Long verificationId);
 }

--- a/src/main/java/com/senity/waved/domain/liked/service/LikedService.java
+++ b/src/main/java/com/senity/waved/domain/liked/service/LikedService.java
@@ -1,0 +1,4 @@
+package com.senity.waved.domain.liked.service;
+
+public interface LikedService {
+}

--- a/src/main/java/com/senity/waved/domain/liked/service/LikedServiceImpl.java
+++ b/src/main/java/com/senity/waved/domain/liked/service/LikedServiceImpl.java
@@ -1,0 +1,4 @@
+package com.senity.waved.domain.liked.service;
+
+public class LikedServiceImpl {
+}

--- a/src/main/java/com/senity/waved/domain/liked/service/LikedServiceImpl.java
+++ b/src/main/java/com/senity/waved/domain/liked/service/LikedServiceImpl.java
@@ -15,13 +15,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class LikedServiceImpl implements LikedService {
     private final VerificationRepository verificationRepository;
     private final MemberRepository memberRepository;
     private final LikedRepository likedRepository;
 
     @Override
+    @Transactional
     public void addLikedToVerification(String email, Long verificationId) {
 
         Member member = getMemberByEmail(email);
@@ -38,7 +38,15 @@ public class LikedServiceImpl implements LikedService {
                 .member(member)
                 .build();
 
+        verification.addLikeToVerification(like);
         likedRepository.save(like);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Long countLikesToVerification(Long verificationId) {
+        Verification verification = getVerificationById(verificationId);
+        return likedRepository.countLikesByVerification(verification);
     }
 
     private Verification getVerificationById(Long id) {

--- a/src/main/java/com/senity/waved/domain/liked/service/LikedServiceImpl.java
+++ b/src/main/java/com/senity/waved/domain/liked/service/LikedServiceImpl.java
@@ -1,4 +1,53 @@
 package com.senity.waved.domain.liked.service;
 
-public class LikedServiceImpl {
+import com.senity.waved.domain.liked.entity.Liked;
+import com.senity.waved.domain.liked.exception.DuplicationLikeException;
+import com.senity.waved.domain.liked.repository.LikedRepository;
+import com.senity.waved.domain.member.entity.Member;
+import com.senity.waved.domain.member.exception.MemberNotFoundException;
+import com.senity.waved.domain.member.repository.MemberRepository;
+import com.senity.waved.domain.verification.entity.Verification;
+import com.senity.waved.domain.verification.exception.VerificationNotFoundException;
+import com.senity.waved.domain.verification.repository.VerificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LikedServiceImpl implements LikedService {
+    private final VerificationRepository verificationRepository;
+    private final MemberRepository memberRepository;
+    private final LikedRepository likedRepository;
+
+    @Override
+    public void addLikedToVerification(String email, Long verificationId) {
+
+        Member member = getMemberByEmail(email);
+        Verification verification = getVerificationById(verificationId);
+
+        boolean hasAlreadyLiked = likedRepository.existsByMemberAndVerification(member, verification);
+
+        if (hasAlreadyLiked) {
+            throw new DuplicationLikeException("이미 좋아요를 누른 인증 내역 입니다.");
+        }
+
+        Liked like = Liked.builder()
+                .verification(verification)
+                .member(member)
+                .build();
+
+        likedRepository.save(like);
+    }
+
+    private Verification getVerificationById(Long id) {
+        return verificationRepository.findById(id)
+                .orElseThrow(() -> new VerificationNotFoundException("해당 인증내역을 찾을 수 없습니다."));
+    }
+
+    private Member getMemberByEmail(String email) {
+        return memberRepository.getMemberByEmail(email)
+                .orElseThrow(() -> new MemberNotFoundException("해당 회원을 찾을 수 없습니다."));
+    }
 }

--- a/src/main/java/com/senity/waved/domain/liked/service/LikedServiceImpl.java
+++ b/src/main/java/com/senity/waved/domain/liked/service/LikedServiceImpl.java
@@ -2,6 +2,7 @@ package com.senity.waved.domain.liked.service;
 
 import com.senity.waved.domain.liked.entity.Liked;
 import com.senity.waved.domain.liked.exception.DuplicationLikeException;
+import com.senity.waved.domain.liked.exception.LikeNotAuthorizedException;
 import com.senity.waved.domain.liked.repository.LikedRepository;
 import com.senity.waved.domain.member.entity.Member;
 import com.senity.waved.domain.member.exception.MemberNotFoundException;
@@ -47,6 +48,19 @@ public class LikedServiceImpl implements LikedService {
     public Long countLikesToVerification(Long verificationId) {
         Verification verification = getVerificationById(verificationId);
         return likedRepository.countLikesByVerification(verification);
+    }
+
+    @Override
+    @Transactional
+    public void removeLikeFromVerification(String email, Long verificationId) {
+        Member member = getMemberByEmail(email);
+        Verification verification = getVerificationById(verificationId);
+
+        Liked liked = likedRepository.findByMemberAndVerification(member, verification)
+                .orElseThrow(() -> new LikeNotAuthorizedException("해당 인증 내역에 좋아요를 누르지 않았습니다."));
+
+        verification.removeLikeFromVerification(liked);
+        likedRepository.delete(liked);
     }
 
     private Verification getVerificationById(Long id) {

--- a/src/main/java/com/senity/waved/domain/verification/entity/Verification.java
+++ b/src/main/java/com/senity/waved/domain/verification/entity/Verification.java
@@ -2,14 +2,17 @@ package com.senity.waved.domain.verification.entity;
 
 import com.senity.waved.common.BaseEntity;
 import com.senity.waved.domain.challenge.entity.VerificationType;
-
 import com.senity.waved.domain.challengeGroup.entity.ChallengeGroup;
+import com.senity.waved.domain.liked.entity.Liked;
 import com.senity.waved.domain.member.entity.Member;
 import jakarta.persistence.*;
-
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -27,6 +30,10 @@ public class Verification extends BaseEntity {
     @Column(name = "verification_type")
     private VerificationType verificationType;
 
+    @Builder.Default
+    @Column(name = "likes_count", nullable = false)
+    private Long likedsCount = 0L;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
@@ -34,6 +41,9 @@ public class Verification extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "challenge_group_id")
     private ChallengeGroup challengeGroup;
+
+    @OneToMany(mappedBy = "verification", cascade = CascadeType.ALL)
+    private List<Liked> likeds = new ArrayList<>();
 
     public static Verification createGithubVerification(Member member, ChallengeGroup challengeGroup, boolean hasCommitsToday) {
         return Verification.builder()

--- a/src/main/java/com/senity/waved/domain/verification/entity/Verification.java
+++ b/src/main/java/com/senity/waved/domain/verification/entity/Verification.java
@@ -32,7 +32,7 @@ public class Verification extends BaseEntity {
 
     @Builder.Default
     @Column(name = "likes_count", nullable = false)
-    private Long likedsCount = 0L;
+    private Long likesCount = 0L;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
@@ -52,5 +52,11 @@ public class Verification extends BaseEntity {
                 .challengeGroup(challengeGroup)
                 .verificationType(VerificationType.GITHUB)
                 .build();
+    }
+
+    public void addLikeToVerification(Liked like) {
+        this.likeds.add(like);
+        like.setVerification(this);
+        this.likesCount++;
     }
 }

--- a/src/main/java/com/senity/waved/domain/verification/entity/Verification.java
+++ b/src/main/java/com/senity/waved/domain/verification/entity/Verification.java
@@ -59,4 +59,10 @@ public class Verification extends BaseEntity {
         like.setVerification(this);
         this.likesCount++;
     }
+
+    public void removeLikeFromVerification(Liked like) {
+        this.likeds.remove(like);
+        like.setVerification(null);
+        this.likesCount--;
+    }
 }

--- a/src/main/java/com/senity/waved/domain/verification/entity/Verification.java
+++ b/src/main/java/com/senity/waved/domain/verification/entity/Verification.java
@@ -43,7 +43,7 @@ public class Verification extends BaseEntity {
     private ChallengeGroup challengeGroup;
 
     @OneToMany(mappedBy = "verification", cascade = CascadeType.ALL)
-    private List<Liked> likeds = new ArrayList<>();
+    private List<Liked> likes = new ArrayList<>();
 
     public static Verification createGithubVerification(Member member, ChallengeGroup challengeGroup, boolean hasCommitsToday) {
         return Verification.builder()
@@ -55,13 +55,13 @@ public class Verification extends BaseEntity {
     }
 
     public void addLikeToVerification(Liked like) {
-        this.likeds.add(like);
+        this.likes.add(like);
         like.setVerification(this);
         this.likesCount++;
     }
 
     public void removeLikeFromVerification(Liked like) {
-        this.likeds.remove(like);
+        this.likes.remove(like);
         like.setVerification(null);
         this.likesCount--;
     }

--- a/src/main/java/com/senity/waved/domain/verification/exception/VerificationNotFoundException.java
+++ b/src/main/java/com/senity/waved/domain/verification/exception/VerificationNotFoundException.java
@@ -1,0 +1,7 @@
+package com.senity.waved.domain.verification.exception;
+
+public class VerificationNotFoundException extends RuntimeException {
+    public VerificationNotFoundException (String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/senity/waved/domain/verification/exception/VerifyExistenceOnDate.java
+++ b/src/main/java/com/senity/waved/domain/verification/exception/VerifyExistenceOnDate.java
@@ -1,0 +1,7 @@
+package com.senity.waved.domain.verification.exception;
+
+public class VerifyExistenceOnDate extends RuntimeException {
+    public VerifyExistenceOnDate (String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
<!-- Assignees는 본인, Reviewrs는 팀원 선택 -->

## #️⃣연관된 이슈

> ex) #33 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
>
>  어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 1. 좋아요 추가 API : 중복 불가능 하도록 에러 처리했습니다.
> 2. 특정 인증 내역 좋아요 수 조회 : liked 엔티티 수를 조회하는 방식으로 구현해서 동시성 문제가 없을 것 같다고 판단했는데, 테스트 후 이슈 발생 시 락 적용하겠습니다.
>  - db 원자성 보장 → db작업이 완전히 수행되거나 전혀 수행되지 않음
>  - 격리수준(트랜잭션활용)으로 트랜잭션을 활용해서 동시에 여러 개의 좋아요가 발생해도 엔티티 개수 조회하는 트랜잭션은 변경되지 않는 데이터 읽어서 높은 격리 수준을 가짐

> 3. 날짜별 인증 내역 조회 페이지에서 좋아요 수(likesCount) 필요하시다고 하셔서 추가했습니다.
> 4. 좋아요 취소 -> 좋아요 누른 사람만 취소할 수 있도록 처리했습니다.
> 5. 좋아요 여부(isLiked)-> 해당 멤버가 해당 인증 내역을 좋아요 했는지 여부를 날짜별 인증 내역 조회 페이지에서 response로 반환했습니다.

- 참고
<img width="804" alt="스크린샷 2024-03-16 오전 1 56 05" src="https://github.com/Senity-Waved/Waved_BE/assets/82140052/d016e4b5-8a7d-4cfc-99d3-e4c0910087f9">

## 체크리스트
- [x] Reviewrs를 설정했습니다
